### PR TITLE
Circumvent docker TTY problem

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,7 +15,8 @@ tasks:
       go mod download
     command: |
       export MM_SERVICESETTINGS_SITEURL=$(gp url 8065)
-      make run-server
+      go run ./build/docker-compose-generator/main.go postgres minio | docker-compose -f docker-compose.makefile.yml -f /dev/stdin run -T --rm start_dependencies
+      make run-server MM_NO_DOCKER=true
     env:
       ENABLED_DOCKER_SERVICES: postgres minio
 


### PR DESCRIPTION
#### Summary

When running `make run-server`, Gitpod is showing this error when spinning up the project's Docker containers:

```
Starting docker containers
go run ./build/docker-compose-generator/main.go postgres minio  | docker-compose -f docker-compose.makefile.yml -f /dev/stdin  run --rm start_dependencies
[+] Running 3/3
 ⠿ Network mattermost-server_mm-test  Created                                                                               0.2s
 ⠿ Container mattermost-postgres      Created                                                                               2.8s
 ⠿ Container mattermost-minio         Created                                                                               2.8s
[+] Running 2/2
 ⠿ Container mattermost-minio     Started                                                                                   1.0s
 ⠿ Container mattermost-postgres  Started                                                                                   1.0s
the input device is not a TTY
make: *** [Makefile:193: start-docker] Error 1
```

From reading https://github.com/docker/compose/issues/5696#issuecomment-425112003, I've changed this to run the `docker-compose run` command manually, with the `-T` flag. This makes it so the Docker containers spin up without the `TTY` error.

We then run `make run-server` with the `MM_NO_DOCKER` variable set to `true`, signaling that we want the script to skip creating the Docker containers, and assume they are already running.