### PR TITLE
Use dockerfile to support cypress tests

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,20 @@
+# You can find the new timestamped tags here: https://hub.docker.com/r/gitpod/workspace-full/tags
+FROM gitpod/workspace-full
+RUN sudo apt-get update
+
+# Install Cypress-base dependencies
+RUN sudo apt-get install -y \
+    libgtk2.0-0 \
+    libgtk-3-0
+RUN sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+    libgbm-dev \
+    libnotify-dev
+RUN sudo apt-get install -y \
+    libgconf-2-4 \
+    libnss3 \
+    libxss1
+RUN sudo apt-get install -y \
+    libasound2 \
+    libxtst6 \
+    xauth \
+    xvfb

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,20 +1,18 @@
-# You can find the new timestamped tags here: https://hub.docker.com/r/gitpod/workspace-full/tags
-FROM gitpod/workspace-full
-RUN sudo apt-get update
+FROM gitpod/workspace-full-vnc
 
-# Install Cypress-base dependencies
-RUN sudo apt-get install -y \
-    libgtk2.0-0 \
-    libgtk-3-0
-RUN sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq \
-    libgbm-dev \
-    libnotify-dev
-RUN sudo apt-get install -y \
-    libgconf-2-4 \
-    libnss3 \
-    libxss1
-RUN sudo apt-get install -y \
-    libasound2 \
-    libxtst6 \
-    xauth \
-    xvfb
+ENV CYPRESS_CACHE_FOLDER=/workspace/.cypress-cache
+
+# Install Cypress dependencies.
+RUN sudo apt-get update \
+ && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+   libgtk2.0-0 \
+   libgtk-3-0 \
+   libnotify-dev \
+   libgconf-2-4 \
+   libnss3 \
+   libxss1 \
+   libasound2 \
+   libxtst6 \
+   xauth \
+   xvfb \
+ && sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,6 +6,21 @@ ports:
   - port: 8065
     onOpen: open-browser
 
+image:
+  file: .gitpod.Dockerfile
+
+github:
+  prebuilds:
+    master: true
+    pullRequests: true
+
+vscode:
+  extensions:
+    - golang.go
+
+workspaceLocation:
+  mattermost-gitpod-config/mattermost.code-workspace
+
 tasks:
   - name: Server
     before: |
@@ -72,15 +87,3 @@ tasks:
       source /workspace/mattermost-gitpod-config/scripts/app/init-app-project.sh
     command: |
       source /workspace/mattermost-gitpod-config/scripts/app/run-app-project.sh
-
-github:
-  prebuilds:
-    master: true
-    pullRequests: true
-
-vscode:
-  extensions:
-    - golang.go
-
-workspaceLocation:
-  mattermost-gitpod-config/mattermost.code-workspace


### PR DESCRIPTION
#### Summary

Inspiration from https://github.com/mikenikles/cypress-on-gitpod

This PR makes it so Gitpod can run tests using a headless chrome browser. In order to get tests to run, I modified the webapp's `cypress:run` command from:

```
cross-env TZ=Etc/UTC cypress run --browser chrome --config ignoreTestFiles='**/enterprise/**/*.{js,ts}'
```

```
cross-env TZ=Etc/UTC cypress run --browser chrome
```

As I was getting this error with the original command:

```
The following configuration option is invalid:

 - ignoreTestFiles
```

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-gitpod-config/issues/9

