### PR TITLE
Set 8065 port visibility to public

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,6 +5,7 @@ additionalRepositories:
 ports:
   - port: 8065
     onOpen: open-browser
+    visibility: public
 
 image:
   file: .gitpod.Dockerfile


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

