### PR TITLE
Change GOBIN to be persisted by workspace

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -20,6 +20,6 @@ RUN sudo apt-get update \
 RUN mkdir -p /workspace/persist/.cache/go-build
 ENV GOCACHE=/workspace/persist/.cache/go-build
 
-ENV GOBIN=/home/gitpod/go/bin
+ENV GOBIN=/workspace/go/bin
 
 ENV MM_SERVICESETTINGS_ENABLEDEVELOPER=true


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Only files in the `/workspace` folder are persisted across resuming workspaces. This PR makes it so the `GOBIN` location has its state persisted.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

