### PR TITLE
Add env var for open server and port for Cypress

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,12 +3,10 @@ additionalRepositories:
   - url: https://github.com/mattermost/mattermost-webapp
 
 ports:
-  # 8065 - for Mattermost instance
   - port: 8065
-    description: 8065 - for Mattermost instance
+    description: for Mattermost instance
     onOpen: open-browser
     visibility: public
-  # 6080 - for noVNC instance (Cypress)
   - port: 6080
     description: for noVNC instance (Cypress)
     onOpen: notify

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,12 @@ additionalRepositories:
   - url: https://github.com/mattermost/mattermost-webapp
 
 ports:
+  # 8065 - for Mattermost instance
   - port: 8065
+    onOpen: open-browser
+    visibility: public
+  # 6080 - for noVNC instance (Cypress)
+  - port: 6080
     onOpen: open-browser
     visibility: public
 
@@ -41,6 +46,7 @@ tasks:
       MM_SERVICESETTINGS_ENABLEOAUTHSERVICEPROVIDER: true
       MM_SERVICESETTINGS_ENABLEDEVELOPER: true
       MM_SERVICESETTINGS_ENABLETESTING: true
+      MM_TEAMSETTINGS_ENABLEOPENSERVER: true
       MM_PLUGINSETTINGS_AUTOMATICPREPACKAGEDPLUGINS: true
       MM_PLUGINSETTINGS_ENABLEUPLOADS: true
       MM_EXPERIMENTALSETTINGS_ENABLEAPPBAR: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,12 +5,19 @@ additionalRepositories:
 ports:
   # 8065 - for Mattermost instance
   - port: 8065
+    description: 8065 - for Mattermost instance
     onOpen: open-browser
     visibility: public
   # 6080 - for noVNC instance (Cypress)
   - port: 6080
-    onOpen: open-browser
-    visibility: public
+    description: for noVNC instance (Cypress)
+    onOpen: notify
+  - port: 5432
+    onOpen: ignore
+  - port: 5900
+    onOpen: ignore
+  - port: 9000
+    onOpen: ignore
 
 image:
   file: .gitpod.Dockerfile


### PR DESCRIPTION
#### Summary
Adds an environment variable for TeamSettings - EnableOpenServer (gets set to `true`), and sets a port for noVNC/Cypress (running `npm run cypress:open` in `mattermost-webapp/e2e/cypress` will open up the Cypress app at `6080`).

#### Ticket Link
N/A, but related issue: https://github.com/mattermost/mattermost-gitpod-config/issues/17

