### PR TITLE
Add environment variables for Boards/Playbooks

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -36,6 +36,8 @@ tasks:
     before: |
       cd ../mattermost-server/server
       export MM_SERVICESETTINGS_SITEURL=$(gp url 8065)
+      export MM_BOARDS_DEV_SERVER_URL=$(gp url 9006)
+      export MM_PLAYBOOKS_DEV_SERVER_URL=$(gp url 9007)
     init: |
       go run ./build/docker-compose-generator/main.go postgres minio | docker-compose -f docker-compose.makefile.yml pull
       make run-server
@@ -64,6 +66,8 @@ tasks:
     before: |
       cd ../mattermost-server/webapp
       export MM_SERVICESETTINGS_SITEURL=$(gp url 8065)
+      export MM_BOARDS_DEV_SERVER_URL=$(gp url 9006)
+      export MM_PLAYBOOKS_DEV_SERVER_URL=$(gp url 9007)
       nvm install
       nvm alias default $(cat .nvmrc)
       echo "nvm use default" >> ~/.bashrc


### PR DESCRIPTION
#### Summary
I haven't tested these myself, but these variables are also needed to get the module federation for Playbooks/Boards set up since the default `localhost` IPs don't work. Without them, the main web app's Webpack instance can't find the Webpack dev servers used by Playbooks and Boards.

More context: https://community.mattermost.com/core/pl/dd5f5ejmzifxuceo4jkt1aseqo
