### PR TITLE
Remove `make build` from webapp init block

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -36,8 +36,8 @@ tasks:
     before: |
       cd ../mattermost-server/server
       export MM_SERVICESETTINGS_SITEURL=$(gp url 8065)
-      export MM_BOARDS_DEV_SERVER_URL=$(gp url 9006)
-      export MM_PLAYBOOKS_DEV_SERVER_URL=$(gp url 9007)
+      export MM_BOARDS_DEV_SERVER_URL=$(gp url 9006):443
+      export MM_PLAYBOOKS_DEV_SERVER_URL=$(gp url 9007):443
     init: |
       go run ./build/docker-compose-generator/main.go postgres minio | docker-compose -f docker-compose.makefile.yml pull
       make run-server
@@ -66,8 +66,8 @@ tasks:
     before: |
       cd ../mattermost-server/webapp
       export MM_SERVICESETTINGS_SITEURL=$(gp url 8065)
-      export MM_BOARDS_DEV_SERVER_URL=$(gp url 9006)
-      export MM_PLAYBOOKS_DEV_SERVER_URL=$(gp url 9007)
+      export MM_BOARDS_DEV_SERVER_URL=$(gp url 9006):443
+      export MM_PLAYBOOKS_DEV_SERVER_URL=$(gp url 9007):443
       nvm install
       nvm alias default $(cat .nvmrc)
       echo "nvm use default" >> ~/.bashrc

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -77,7 +77,6 @@ tasks:
       ln -nfs ../webapp/channels/dist client
       cd ../webapp
       npm i
-      make build
       echo "Webapp built"
     command: |
       npm i


### PR DESCRIPTION
#### Summary

[Open in Gitpod](https://gitpod.io/#https://github.com/mattermost/mattermost-gitpod-config/pull/39)

From the discussion here https://github.com/mattermost/mattermost-gitpod-config/pull/38#issuecomment-1523742460, there is an issue with running `make build` for the webapp, as this compiles it for production rather than development. Because of this, there are some artifacts left over when running the development version from `make run`.

This PR makes it so we don't run `make build` anymore.

#### Ticket Link