### PR TITLE
Display a welcome page about the Gitpod cloud workspace for Mattermost

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -17,6 +17,8 @@ RUN sudo apt-get update \
    xvfb \
  && sudo rm -rf /var/lib/apt/lists/*
 
+RUN npm i -g markserv
+
 RUN mkdir -p /workspace/persist/.cache/go-build
 ENV GOCACHE=/workspace/persist/.cache/go-build
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,7 @@ ports:
     visibility: public
   - port: 9000
     description: for Mattermost + Gitpod welcome message
-    onOpen: open-browser
+    onOpen: open-preview
     visibility: public
   - port: 6080
     description: for noVNC instance (Cypress)

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -39,6 +39,7 @@ tasks:
       npm i -g markserv
     command: |
       markserv -p 9000 welcome.md
+
   - name: Server
     before: |
       cd workspace/mattermost/server

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -40,7 +40,7 @@ tasks:
     before: |
       npm i -g markserv
       markserv -p 9000 &
-      gp open "$(gp url 9000)/welcome.md"
+      gp preview "$(gp url 9000)/welcome.md"
       cd workspace/mattermost/server
       export MM_SERVICESETTINGS_SITEURL=$(gp url 8065)
     init: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,6 +6,8 @@ ports:
     description: for Mattermost instance
     onOpen: open-browser
     visibility: public
+  - port: 9000
+    description: for Mattermost + Gitpod welcome message
   - port: 6080
     description: for noVNC instance (Cypress)
     onOpen: notify
@@ -29,12 +31,13 @@ vscode:
   extensions:
     - golang.go
 
-workspaceLocation:
-  mattermost-gitpod-config/mattermost.code-workspace
+workspaceLocation: mattermost-gitpod-config/mattermost.code-workspace
 
 tasks:
   - name: Server
     before: |
+      npm i -g markserv
+      markserve ./welcome.md -p 9000 &
       cd ../mattermost/server
       export MM_SERVICESETTINGS_SITEURL=$(gp url 8065)
     init: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,6 +8,8 @@ ports:
     visibility: public
   - port: 9000
     description: for Mattermost + Gitpod welcome message
+    onOpen: open-browser
+    visibility: public
   - port: 6080
     description: for noVNC instance (Cypress)
     onOpen: notify
@@ -37,8 +39,9 @@ tasks:
   - name: Server
     before: |
       npm i -g markserv
-      markserv ./welcome.md -p 9000 &
-      cd ../mattermost/server
+      markserv -p 9000 &
+      gp open "$(gp url 9000)/welcome.md"
+      cd workspace/mattermost/server
       export MM_SERVICESETTINGS_SITEURL=$(gp url 8065)
     init: |
       go run ./build/docker-compose-generator/main.go postgres minio | docker-compose -f docker-compose.makefile.yml pull

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -35,9 +35,9 @@ workspaceLocation: mattermost-gitpod-config/mattermost.code-workspace
 tasks:
   - name: Welcome
     command: |
-      markserv -p 9000 --browser false welcome.md &
+      markserv -p 9000 --browser false &
       sleep 2
-      gp preview $(gp url 9000)
+      gp preview "$(gp url 9000)/welcome.md"
 
   - name: Server
     before: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -38,10 +38,13 @@ workspaceLocation: mattermost-gitpod-config/mattermost.code-workspace
 tasks:
   - name: Server
     before: |
+  - name: Welcome
+    init: |
       npm i -g markserv
+    command: |
       markserv -p 9000 &
       gp preview "$(gp url 9000)/welcome.md"
-      cd workspace/mattermost/server
+      exit
       export MM_SERVICESETTINGS_SITEURL=$(gp url 8065)
     init: |
       go run ./build/docker-compose-generator/main.go postgres minio | docker-compose -f docker-compose.makefile.yml pull

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,7 +9,6 @@ ports:
   - port: 9000
     description: for Mattermost + Gitpod welcome message
     onOpen: ignore
-    visibility: public
   - port: 6080
     description: for noVNC instance (Cypress)
     onOpen: notify
@@ -35,11 +34,10 @@ workspaceLocation: mattermost-gitpod-config/mattermost.code-workspace
 
 tasks:
   - name: Welcome
-    init: |
-      npm i -g markserv
     command: |
-      markserv -p 9000 &
-      gp preview "$(gp url 9000)/welcome.md"
+      markserv -p 9000 --browser false welcome.md &
+      sleep 2
+      gp preview $(gp url 9000)
 
   - name: Server
     before: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -38,7 +38,8 @@ tasks:
     init: |
       npm i -g markserv
     command: |
-      markserv -p 9000 welcome.md
+      markserv -p 9000 &
+      gp preview "$(gp url 9000)/welcome.md"
 
   - name: Server
     before: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,8 +17,6 @@ ports:
     onOpen: ignore
   - port: 5900
     onOpen: ignore
-  - port: 9000
-    onOpen: ignore
 
 image:
   file: .gitpod.Dockerfile
@@ -36,15 +34,14 @@ vscode:
 workspaceLocation: mattermost-gitpod-config/mattermost.code-workspace
 
 tasks:
-  - name: Server
-    before: |
   - name: Welcome
     init: |
       npm i -g markserv
     command: |
-      markserv -p 9000 &
-      gp preview "$(gp url 9000)/welcome.md"
-      exit
+      markserv -p 9000 welcome.md
+  - name: Server
+    before: |
+      cd workspace/mattermost/server
       export MM_SERVICESETTINGS_SITEURL=$(gp url 8065)
     init: |
       go run ./build/docker-compose-generator/main.go postgres minio | docker-compose -f docker-compose.makefile.yml pull

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -37,7 +37,7 @@ tasks:
   - name: Server
     before: |
       npm i -g markserv
-      markserve ./welcome.md -p 9000 &
+      markserv ./welcome.md -p 9000 &
       cd ../mattermost/server
       export MM_SERVICESETTINGS_SITEURL=$(gp url 8065)
     init: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -41,7 +41,7 @@ tasks:
 
   - name: Server
     before: |
-      cd workspace/mattermost/server
+      cd /workspace/mattermost/server
       export MM_SERVICESETTINGS_SITEURL=$(gp url 8065)
     init: |
       go run ./build/docker-compose-generator/main.go postgres minio | docker-compose -f docker-compose.makefile.yml pull
@@ -69,7 +69,7 @@ tasks:
 
   - name: Webapp
     before: |
-      cd ../mattermost/webapp
+      cd /workspace/mattermost/webapp
       export MM_SERVICESETTINGS_SITEURL=$(gp url 8065)
       nvm install
       nvm alias default $(cat .nvmrc)
@@ -88,12 +88,12 @@ tasks:
 
   - name: Cypress
     init: |
-      cd ../mattermost/e2e-tests/cypress
+      cd /workspace/mattermost/e2e-tests/cypress
       npm i
 
   - name: Playwright
     init: |
-      cd ../mattermost/e2e-tests/playwright
+      cd /workspace/mattermost/e2e-tests/playwright
       npm i
       npx playwright install
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,7 @@ ports:
     visibility: public
   - port: 9000
     description: for Mattermost + Gitpod welcome message
-    onOpen: open-preview
+    onOpen: ignore
     visibility: public
   - port: 6080
     description: for noVNC instance (Cypress)

--- a/welcome.md
+++ b/welcome.md
@@ -1,0 +1,14 @@
+[Gitpod](https://gitpod.io/) is a cloud development environment. We recommend checking out the [Mattermost + Gitpod guide](https://developers.mattermost.com/contribute/more-info/getting-started/using-gitpod/) in the Mattermost developer docs.
+
+# Welcome to your very own Mattermost Gitpod workspace 🎉
+
+We're setting up your environment in the terminals below 👇
+
+- **Server**: Installs server dependencies, then runs the server
+- **Webapp**: Install webapp dependencies, then runs a webpack process that continuously watches the source code for changes, and recompiles
+- **Plugin**: If the workspace was opened from a plugin repository, the plugin is built and deployed to the Mattermost server running in Gitpod
+- **App**: Runs code defined in the workspace repository in the files optionally defined in `.gitpod/init.sh` and `.gitpod/command.sh`
+
+You can also check out these videos to learn how to work with Gitpod (and write an E2E test):
+- [How to set up a developer environment for Mattermost with Gitpod](https://www.youtube.com/watch?v=LgQ2Z_GelYQ)
+- [Writing your first E2E test for Mattermost](https://www.youtube.com/watch?v=mLbzKSGZv4A).


### PR DESCRIPTION
Closes #22 

**Changes:**
- installs [markserv](https://github.com/markserv/markserv) globally
- adds a new `welcome.md` file to load in the preview window
- includes additional links like the [Mattermost + Gitpod guide](https://developers.mattermost.com/contribute/more-info/getting-started/using-gitpod/) and links to YouTube video resources

**Future ideas:**
- make `welcome.md` more useful and visually engaging
- change load order so it loads ASAP
- see if we can hide the default preview window and replace it with our loaded one